### PR TITLE
fix on base class static side extension

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -15,13 +15,13 @@ export default class MyDocument extends Document {
             const initialProps = await Document.getInitialProps(ctx);
             return {
                 ...initialProps,
-                styles: (
-                    <>
-                        {initialProps.styles}
-                        {sheet.getStyleElement()}
-                    </>
-                ),
-            };
+                styles: [
+                  <>
+                    {initialProps.styles}
+                    {sheet.getStyleElement()}
+                  </>,
+                ],
+              };
         } finally {
             sheet.seal();
         }


### PR DESCRIPTION
Fix of the following error as shown in VS Code: "class static side 'typeof mydocument' incorrectly extends base class static side 'typeof document'. the types returned by 'getinitialprops(...)' are incompatible between these types. type 'promise<{ styles: element; html: string; head?: (element | null)[] | undefined; }>' is not assignable to type 'promise<documentinitialprops>'. type '{ styles: jsx.element; html: string; head?: (jsx.element | null)[] | undefined; }' is not assignable to type 'documentinitialprops'. type '{ styles: jsx.element; html: string; head?: (jsx.element | null)[] | undefined; }' is not assignable to type '{ styles?: reactelement<any, string | jsxelementconstructor<any>>[] | reactfragment | undefined; }'. types of property 'styles' are incompatible. type 'element' is not assignable to type 'reactelement<any, string | jsxelementconstructor<any>>[] | reactfragment | undefined'."

This error causes a failure in deployment.